### PR TITLE
Cmake updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ python:
 script:
   - cd bld; ./cvmix_setup gfortran $(dirname $(dirname $(which nc-config)))
   - cd ../CVMix_tools; ./run_test_suite.sh --already-ran-setup
+  - cd ../reg_tests/Bryan-Lewis/; ./Bryan-Lewis-test.sh --cmake
 
 branches:
   only:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,8 @@ add_subdirectory( src )
 # Note - KB:
 # Building static and shared libs require an ugly construct to build on both
 # Windows and Linux. Windows will not create the libraries unless a Fortran
-# file is explicitly given - and Linux complains (I think due to a race 
-# condition) if it is. Therefor the construct below - a proper solution is 
+# file is explicitly given - and Linux complains (I think due to a race
+# condition) if it is. Therefor the construct below - a proper solution is
 # most welcome.
 
 # Add static lib target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.10 )
+cmake_minimum_required( VERSION 3.9 )
 
 project( cvmix VERSION 4.0.1 LANGUAGES Fortran )
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ INSTALLATION NOTES
 ------------------
 
 CVMix can be installed using two different methods. The original uses Make
-and a set of Makefiles. The new method uses CMake and two CMakelists.txt 
+and a set of Makefiles. The new method uses CMake and two CMakelists.txt
 files.
 
 #### Building/installing using Make
@@ -72,42 +72,39 @@ to configure and compile CVMix. Note that CVMix has been build on Windows using
 VisualStudio and the Intel Fortran compiler but NetCDF support has not been
 tested.
 
-In this recipe CVMIX\_BASE s a convinience environmental variable pointing to 
-the CVMix source directory. It is possible to execute the following commands 
-providing the full path.
-
-
-1. mkdir ~/build/cvmix
-   * [CMake](https://cmake.org/) promotes out of source compilation
-2. cd ~/build/cvmix
-3. cmake $CVMIX\_BASE 
+1. cd $CVMix/bld/cmake_bld
+   * [CMake](https://cmake.org/) promotes out of source compilation,
+     any such directory will do.
+2. cmake $CVMix
    * The simplest configuration - using default Fortran compiler
-4. cmake $CVMIX\_BASE -DCMAKE\_Fortran\_COMPILER=ifort
+3. cmake $CVMix -DCMAKE\_Fortran\_COMPILER=ifort
    * Specifying a Fortran compiler
-5. cmake $CVMIX\_BASE -DCVMIX\_BUILD\_DRIVER=on
+4. cmake $CVMix -DCVMIX\_BUILD\_DRIVER=on
    * Build the CVMix driver program - off by default
-6. cmake $CVMIX\_BASE -DCVMIX\_BUILD\_DRIVER=on CVMIX\_USE\_NetCDF=on
+5. cmake $CVMix -DCVMIX\_BUILD\_DRIVER=on CVMIX\_USE\_NetCDF=on
    * Include support for NetCDF in the driver model(1)
    * Note that this requires proper configuration of the installed NetCDF library.
    * Setting NetCDF\_INCLUDE and NetCDF\_LIBRARIES might help.
-7. cmake $CVMIX\_BASE -DCMAKE\_INSTALL\_PREFIX=~/local
-   * Providing an installation folder
+6. cmake $CVMix -DCMAKE\_INSTALL\_PREFIX=$CVMix/bin
+   * Providing an installation folder (again, any such directory will do)
 
 Combination of the above commands is possible.
 
 After configuration has been done compilation is as simple as:
+
 ```
 make
 ```
 
 and instllation by:
+
 ```
 make install
 ```
 
 After installation the build directory can be removed.
 
-The support for CMake builds provides sufficient infrastructure for CVMix 
+The support for CMake builds provides sufficient infrastructure for CVMix
 being included in ocean models using the GIT submodule feature. This has
 been used in the [GOTM](https:/gotm.net) inclusion of the CVMix mixing
 models as a supplement to the original turbulence models in GOTM.
@@ -120,7 +117,7 @@ DIRECTORY STRUCTURE
 bin/ -- Default location for the cvmix executable.
 
 bld/ -- Contains auxiliary files needed by the build system. CompileFlags.mak
-        has default compile flags for 5 different compilers -- gfortran, 
+        has default compile flags for 5 different compilers -- gfortran,
         pgf90, ifort, xlf90, and nagfor, as well as ftn (the Cray wrapper for
         pgf90). At this time, no other compilers are supported on Cray systems.
         cvmix_setup is a python script that saves information about what
@@ -234,7 +231,7 @@ src/ -- Contains the source code, organized as follows. The top directory
 
   src/drivers/ -- Subroutines called by the driver (one per test).
 
-  src/shared/  -- Where all the modules that are needed to use CVMix with an 
+  src/shared/  -- Where all the modules that are needed to use CVMix with an
                   outside model are stored. Also contains the Makefile used to
                   build the libcvmix.a library.
 

--- a/bld/cmake_bld/.gitignore
+++ b/bld/cmake_bld/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/cmake_bin/.gitignore
+++ b/cmake_bin/.gitignore
@@ -1,0 +1,4 @@
+bin
+include
+lib
+cmake

--- a/reg_tests/common/build.sh
+++ b/reg_tests/common/build.sh
@@ -2,8 +2,17 @@
 
 build () {
   if [ -z ${NO_BUILD} ]; then
-    make -f $CVMix/src/Makefile CVMIX_ROOT=$CVMix ${USE_NETCDF}
-    if [ $? != 0 ]; then
+    if [ "${CMAKE_BUILD}" == "TRUE" ]; then
+      CWD=$PWD
+      cd $CVMix/bld/cmake_bld
+      cmake $CVMix -DCVMIX_BUILD_DRIVER=on -DCMAKE_Fortran_COMPILER=gfortran && make
+      STATUS=$?
+      cd $CWD
+    else
+      make -f $CVMix/src/Makefile CVMIX_ROOT=$CVMix ${USE_NETCDF}
+      STATUS=$?
+    fi
+    if [ $STATUS != 0 ]; then
       echo "Build error!"
       exit 2
     fi
@@ -12,7 +21,7 @@ build () {
       if [ "`cat ../../bld/.netcdf_info`" == "YES" ]; then
         USE_NETCDF=netcdf
       fi
-    fi  
+    fi
   fi
 
 }

--- a/reg_tests/common/build.sh
+++ b/reg_tests/common/build.sh
@@ -5,7 +5,10 @@ build () {
     if [ "${CMAKE_BUILD}" == "TRUE" ]; then
       CWD=$PWD
       cd $CVMix/bld/cmake_bld
-      cmake $CVMix -DCVMIX_BUILD_DRIVER=on -DCMAKE_Fortran_COMPILER=gfortran && make
+      cmake $CVMix -DCVMIX_BUILD_DRIVER=on \
+                   -DCMAKE_Fortran_COMPILER=gfortran \
+                   -DCMAKE_INSTALL_PREFIX=$CVMix/cmake_bin \
+      && make && make install
       STATUS=$?
       cd $CWD
     else

--- a/reg_tests/common/parse_inputs.sh
+++ b/reg_tests/common/parse_inputs.sh
@@ -43,6 +43,9 @@ while [ $# -gt 0 ]; do
         bad_input $1
       fi
     ;;
+    -cm|--cmake)
+      CMAKE_BUILD=TRUE
+    ;;
     * )
       bad_input $1
     ;;

--- a/reg_tests/common/run.sh
+++ b/reg_tests/common/run.sh
@@ -2,7 +2,12 @@
 
 run () {
 
-  $CVMix/bin/cvmix < $NAMELIST
+  if [ "${CMAKE_BUILD}" == "TRUE" ]; then
+    CVMIX_EXE=$CVMix/bld/cmake_bld/cvmix_driver
+  else
+    CVMIX_EXE=$CVMix/bin/cvmix
+  fi
+  ${CVMIX_EXE} < $NAMELIST
 
   if [ $? != 0 ]; then
     echo "Error in execution!"

--- a/reg_tests/common/run.sh
+++ b/reg_tests/common/run.sh
@@ -3,7 +3,7 @@
 run () {
 
   if [ "${CMAKE_BUILD}" == "TRUE" ]; then
-    CVMIX_EXE=$CVMix/bld/cmake_bld/cvmix_driver
+    CVMIX_EXE=$CVMix/cmake_bin/bin/cvmix_driver
   else
     CVMIX_EXE=$CVMix/bin/cvmix
   fi


### PR DESCRIPTION
Scripts in each of the subdirectories of `reg_test/` can pass the `--cmake` argument, and it will launch `cmake` from `bld/cmake_bld` and then use the resulting executable (`bld/cmake_bld/cvmix_driver`) instead of `bin/cvmix`.

Some missing features:

1. Ability to clean `bld/cmake_bld`
1. Ability to specify compiler (`gfortran` is hard-coded)
1. netCDF support
1. `--cmake` option in `CVMix_tools/run_test_suite.sh`

But at least it's a way for us to test the `cmake` in Travis.